### PR TITLE
Remove duplicate array key from Hooks

### DIFF
--- a/modules/Core/Hooks.php
+++ b/modules/Core/Hooks.php
@@ -145,7 +145,6 @@ class Hooks {
 		foreach(Property::$taxonomies as $media_taxonomy) {
 			$media_taxonomy_data['taxonomies'][$media_taxonomy->name] = array(
 				'slug' => $media_taxonomy->name,
-				'terms' => [],
 				'terms' => Helpers::get_terms_hierarchical(array(
 					'taxonomy' => $media_taxonomy->name,
 					'hide_empty' => false


### PR DESCRIPTION
Just ran PHPStan again.
@Stibo

From https://github.com/faktorvier/f4-media-taxonomies/commit/907c70ad74c7ec5c2fffac6f8b4036880a75718b#diff-5e80acdbf684fc0ae98b372558086ef34b3833965cc6ae2ca6982fc8b9fa77cf
